### PR TITLE
Fix bs4 css build

### DIFF
--- a/sass/index-bs4.scss
+++ b/sass/index-bs4.scss
@@ -1,5 +1,5 @@
-@import '../node_modules/bootstrap/scss/functions';
-@import '../node_modules/bootstrap/scss/variables';
-@import '../node_modules/bootstrap/scss/mixins';
+@import '../node_modules/bootstrap4/scss/functions';
+@import '../node_modules/bootstrap4/scss/variables';
+@import '../node_modules/bootstrap4/scss/mixins';
 
 @import 'datepicker-bs4';


### PR DESCRIPTION
There is a little error in my last PR.

To allow the build for both bs4 and bs5 I imported the two framworks in dev-dependencies as: 
"bootstrap4": "npm: bootstrap@^4.5.3",
"bootstrap5": "npm: bootstrap@^5.0.1",

So the folder in node_modules for bs4 is bootstrap4 and i forgot to change that in index-bs4.scss

I didn't notice the problem because I hadn't deleted the node_module folder, so the make worked .
But if someone forks the repositories and runs npm init, the make would give an error without this fix 
