### PR TITLE
feat: added focus ignored selector

### DIFF
--- a/js/events/pickerListeners.js
+++ b/js/events/pickerListeners.js
@@ -64,7 +64,7 @@ export function onClickView(datepicker, ev) {
 }
 
 export function onClickPicker(datepicker) {
-  if (!datepicker.inline && !datepicker.config.disableTouchKeyboard) {
+  if (!datepicker.inline && !datepicker.config.disableTouchKeyboard && !ev.target.matches(datepicker.config.focusIgnoredSelector)) {
     datepicker.inputField.focus();
   }
 }

--- a/js/events/pickerListeners.js
+++ b/js/events/pickerListeners.js
@@ -63,7 +63,7 @@ export function onClickView(datepicker, ev) {
   }
 }
 
-export function onClickPicker(datepicker) {
+export function onClickPicker(datepicker, ev) {
   if (!datepicker.inline && !datepicker.config.disableTouchKeyboard && !ev.target.matches(datepicker.config.focusIgnoredSelector)) {
     datepicker.inputField.focus();
   }

--- a/js/options/defaultOptions.js
+++ b/js/options/defaultOptions.js
@@ -13,6 +13,7 @@ const defaultOptions = {
   daysOfWeekHighlighted: [],
   defaultViewDate: undefined, // placeholder, defaults to today() by the program
   disableTouchKeyboard: false,
+  focusIgnoredSelector: null,
   format: 'mm/dd/yyyy',
   language: 'en',
   maxDate: null,


### PR DESCRIPTION
Hi @mymth, this should fix #78

I've added new option `focusIgnoredSelector`, this can be css selector what elements to ignore for focus, eg: `:is([type="time"], .myCustomClassname)` etc