### PR TITLE
Enhance Datepicker be extensible by users to add custom buttons with user specified dates

### DIFF
--- a/demo/bs4.html
+++ b/demo/bs4.html
@@ -129,6 +129,15 @@
             <h4 class="subtitle">Options</h4>
             <form id="options">
 
+                <div class="form-group form-check" data-bs-toggle="tooltip" title="Only effective in range picker">
+                    <input type="checkbox" class="form-check-input" id="addQuickActionQuarter" name="addQuickActionQuarter" value="true">
+                    <label for="addQuickActionQuarter" class="form-check-label">addQuickAction - Start and End Quarter Dates</label>
+                </div>
+                <div class="form-group form-check">
+                    <input type="checkbox" class="form-check-input" id="addQuickActionYesterday" name="addQuickActionYesterday" value="true">
+                    <label for="addQuickActionYesterday" class="form-check-label">addQuickAction - Yesterday</label>
+                </div>
+
               <div class="form-group form-check" data-toggle="tooltip" title="Only effective in range picker">
                 <input type="checkbox" class="form-check-input" id="allowOneSidedRange" name="allowOneSidedRange" value="true">
                 <label for="allowOneSidedRange" class="form-check-label">allowOneSidedRange</label>

--- a/demo/bs5.html
+++ b/demo/bs5.html
@@ -129,6 +129,15 @@
             <h4 class="subtitle">Options</h4>
             <form id="options">
 
+                <div class="mb-3 form-check" data-bs-toggle="tooltip" title="Only effective in range picker">
+                    <input type="checkbox" class="form-check-input" id="addQuickActionQuarter" name="addQuickActionQuarter" value="true">
+                    <label for="addQuickActionQuarter" class="form-check-label">addQuickAction - Start and End Quarter Dates</label>
+                </div>
+                <div class="mb-3 form-check">
+                    <input type="checkbox" class="form-check-input" id="addQuickActionYesterday" name="addQuickActionYesterday" value="true">
+                    <label for="addQuickActionYesterday" class="form-check-label">addQuickAction - Yesterday</label>
+                </div>
+
               <div class="mb-3 form-check" data-bs-toggle="tooltip" title="Only effective in range picker">
                 <input type="checkbox" class="form-check-input" id="allowOneSidedRange" name="allowOneSidedRange" value="true">
                 <label for="allowOneSidedRange" class="form-check-label">allowOneSidedRange</label>

--- a/demo/foundation.html
+++ b/demo/foundation.html
@@ -152,6 +152,16 @@
             <h4 class="subtitle">Options</h4>
             <form id="options">
 
+                <div class="field" data-tooltip title="Only effective in range picker">
+                    <input type="checkbox" id="addQuickActionQuarter" name="addQuickActionQuarter" value="true">
+                    <label for="addQuickActionQuarter">addQuickAction - Start and End Quarter Dates</label>
+                  </div>
+
+                  <div class="field">
+                    <input type="checkbox" id="addQuickActionYesterday" name="addQuickActionYesterday" value="true">
+                    <label for="addQuickActionYesterday">addQuickAction - Yesterday</label>
+                  </div>
+
               <div class="field" data-tooltip title="Only effective in range picker">
                 <input type="checkbox" id="allowOneSidedRange" name="allowOneSidedRange" value="true">
                 <label for="allowOneSidedRange">allowOneSidedRange</label>

--- a/demo/index.html
+++ b/demo/index.html
@@ -126,6 +126,23 @@
             <h4 class="subtitle">Options</h4>
             <form id="options">
 
+                <div class="field">
+                    <div class="control tooltip" data-tooltip="Only effective in range picker">
+                      <label class="label checkbox">
+                        <input type="checkbox" name="addQuickActionQuarter" value="true">
+                        addQuickAction - Start and End Quarter Dates
+                        </label>
+                    </div>
+                </div>
+                <div class="field">
+                    <div class="control tooltip">
+                      <label class="label checkbox">
+                        <input type="checkbox" name="addQuickActionYesterday" value="true">
+                        addQuickAction - Yesterday
+                       </label>
+                    </div>
+                </div>
+
               <div class="field">
                 <div class="control tooltip" data-tooltip="Only effective in range picker">
                   <label class="label checkbox">

--- a/demo/live-demo.js
+++ b/demo/live-demo.js
@@ -219,6 +219,12 @@ function switchPicker(type) {
   window.demoPicker = type === 'range'
     ? new DateRangePicker(el, options)
     : new Datepicker(el, options);
+
+  const formElemByName = name => optsForm.querySelector(`[name="${name}"]`);
+  let addQuickAction = formElemByName('addQuickActionQuarter');
+  updateQuickAction('addQuickActionQuarter', addQuickAction.checked);
+  addQuickAction = formElemByName('addQuickActionYesterday');
+  updateQuickAction('addQuickActionYesterday', addQuickAction.checked);
 }
 
 const setOptions = function setOptions(name, value) {
@@ -242,6 +248,15 @@ const refreshOptionForm = function refreshOptionForm() {
     const allowOneSided = formElemByName('allowOneSidedRange');
     if (allowOneSided.checked) {
       allowOneSided.checked = false;
+    }
+    const addQuickActionQuarter = formElemByName('addQuickActionQuarter');
+    if (addQuickActionQuarter.checked) {
+      addQuickActionQuarter.checked = false;
+    }
+  } else {
+    const addQuickActionYesterday = formElemByName('addQuickActionYesterday');
+    if (addQuickActionYesterday.checked) {
+        addQuickActionYesterday.checked = false;
     }
   }
   Object.entries(datepicker.config).forEach(entry => {
@@ -325,6 +340,44 @@ const handleArrayOption = function handleArrayOption(name) {
   const checkedInputs = options.querySelectorAll(`input[name=${name}]:checked`);
   setOptions(name, Array.from(checkedInputs).map(el => Number(el.value)));
 };
+
+function updateQuickAction(name, value) {
+    // add some quick action buttons
+  const rangePicker = window.demoPicker instanceof DateRangePicker;
+  if (rangePicker && name === 'addQuickActionQuarter') {
+    if (value === true) {
+      var startOfQuarter = function () {
+        var now = new Date();
+        var quarter = Math.floor((now.getMonth() / 3));
+        return new Date(now.getFullYear(), quarter * 3, 1);
+      };
+      window.demoPicker.addQuickControlToRangeStart("Start of Quarter", startOfQuarter);
+
+      var endOfQuarter = function () {
+        var now = new Date();
+        var quarter = Math.floor((now.getMonth() / 3));
+        const firstDate = new Date(now.getFullYear(), quarter * 3, 1);
+        return new Date(firstDate.getFullYear(), firstDate.getMonth() + 3, 0);
+      };
+      window.demoPicker.addQuickControlToRangeEnd("End of Quarter", endOfQuarter);
+    } else {
+      window.demoPicker.removeQuickControlFromRangeStart("Start of Quarter");
+      window.demoPicker.removeQuickControlFromRangeEnd("End of Quarter");
+    }
+  } else if (!rangePicker && name === 'addQuickActionYesterday') {
+    if (value === true) {
+      var dateFunction = function () {
+        const d = new Date();
+        d.setHours(0, 0, 0, 0);
+        d.setDate(d.getDate() - 1);
+        return d;
+      };
+      window.demoPicker.addQuickControl("Yesterday", dateFunction);
+    } else {
+      window.demoPicker.removeQuickControl("Yesterday");
+    }
+  }
+}
 
 function updateOption(name, value) {
   switch (name) {
@@ -439,7 +492,11 @@ function onClickCheckboxOptions(ev) {
   }
 
   const value = checkbox.value === 'true' ? checked : checkbox.value;
-  updateOption(checkbox.name, value);
+  if (checkbox.name === 'addQuickActionQuarter' || checkbox.name === 'addQuickActionYesterday') {
+    updateQuickAction(checkbox.name, value);
+  } else {
+    updateOption(checkbox.name, value);
+  }
 }
 
 function initialize() {

--- a/demo/plain-css.html
+++ b/demo/plain-css.html
@@ -163,6 +163,24 @@
             <h4 class="subtitle">Options</h4>
             <form id="options">
 
+                <div class="field">
+                    <div class="control tooltip" data-tooltip="Only effective in range picker">
+                      <label class="label checkbox">
+                        <input type="checkbox" name="addQuickActionQuarter" value="true">
+                        addQuickAction - Start and End Quarter Dates
+                      </label>
+                    </div>
+                  </div>
+
+                  <div class="field">
+                    <div class="control">
+                      <label class="label checkbox">
+                        <input type="checkbox" name="addQuickActionYesterday" value="true">
+                        addQuickAction - Yesterday
+                      </label>
+                    </div>
+                  </div>
+
               <div class="field">
                 <div class="control tooltip" data-tooltip="Only effective in range picker">
                   <label class="label checkbox">

--- a/js/DateRangePicker.js
+++ b/js/DateRangePicker.js
@@ -207,4 +207,42 @@ export default class DateRangePicker  {
       onChangeDate(this, {target: this.inputs[0]});
     }
   }
+
+  /**
+   * Adds a quick action button at the header of range start picker.
+   * @param {String} btnLabel label for quick action button
+   * @param {Function} onClickQuickControl gets the date on click of this quick action button
+   */
+  addQuickControlToRangeStart(btnLabel, onClickQuickControl) {
+    const datepicker = this.datepickers[0];
+    datepicker.addQuickControl(btnLabel, onClickQuickControl);
+  }
+
+  /**
+   * Removes the quick action button with name, when found from the header of range start picker.
+   * @param {String} btnLabel button's label, the text is case-sensitive to match
+   */
+  removeQuickControlFromRangeStart(btnLabel) {
+    const datepicker = this.datepickers[0];
+    datepicker.removeQuickControl(btnLabel);
+  }
+
+  /**
+   * Adds a quick action button at the header of range end picker.
+   * @param {String} btnLabel label for quick action button
+   * @param {Function} onClickQuickControl gets the date on click of this quick action button
+   */
+  addQuickControlToRangeEnd(btnLabel, onClickQuickControl) {
+    const datepicker = this.datepickers[1];
+    datepicker.addQuickControl(btnLabel, onClickQuickControl);
+  }
+
+  /**
+   * Removes the quick action button with name, when found from the header of range end picker.
+   * @param {String} btnLabel button's label, the text is case-sensitive to match
+   */
+  removeQuickControlFromRangeEnd(btnLabel) {
+    const datepicker = this.datepickers[1];
+    datepicker.removeQuickControl(btnLabel);
+  }
 }

--- a/js/Datepicker.js
+++ b/js/Datepicker.js
@@ -499,4 +499,32 @@ export default class Datepicker {
       this.update(opts);
     }
   }
+
+  /**
+   * Adds a quick action button at the header of the picker.
+   * @param {String} btnLabel label for quick action button
+   * @param {Function} onClickQuickControl gets the date on click of this quick action button
+   */
+  addQuickControl(btnLabel, onClickQuickControl) {
+    // do nothing when required arguments missing
+    if (btnLabel === undefined || onClickQuickControl === undefined || !(onClickQuickControl instanceof Function)) {
+      throw new Error('Button Label or onClickQuickControl is undefined or not a function.');
+    }
+    const quickControlDate = onClickQuickControl();
+    // test and validate that function returns a Date, otherwise don't add to picker
+    if (!(quickControlDate instanceof Date) || isNaN(quickControlDate)) {
+      throw new Error('onClickQuickControl does not return Date');
+    }
+
+    this.picker.addQuickControlButton(this, btnLabel, onClickQuickControl);
+  }
+
+  /**
+   * Removes the button with the label, if any was added as a quick control button.
+   *
+   * @param {String} btnLabel button's label, the text is case-sensitive to match
+   */
+  removeQuickControl(btnLabel) {
+    this.picker.removeQuickControlButton(btnLabel);
+  }
 }

--- a/js/Datepicker.js
+++ b/js/Datepicker.js
@@ -292,7 +292,7 @@ export default class Datepicker {
    */
   show() {
     if (this.inputField) {
-      if (this.inputField.disabled) {
+      if (this.inputField.disabled || this.inputField.hasAttribute('readonly')) {
         return;
       }
       if (!isActiveElement(this.inputField) && !this.config.disableTouchKeyboard) {

--- a/js/events/pickerListeners.js
+++ b/js/events/pickerListeners.js
@@ -30,6 +30,24 @@ export function onClickTodayBtn(datepicker) {
   picker.changeView(0).render();
 }
 
+export function onClickQuickControl(datepicker, controlDate) {
+  const quickControlDate = controlDate();
+
+  const picker = datepicker.picker;
+  if (datepicker.config.autohide) {
+    datepicker.setDate(quickControlDate);
+    return;
+  } else {
+    datepicker.setDate(quickControlDate, { render: true });
+    picker.update();
+  }
+
+  if (picker.viewDate !== quickControlDate) {
+    picker.changeFocus(quickControlDate);
+  }
+  picker.changeView(0).render();
+}
+
 export function onClickClearBtn(datepicker) {
   datepicker.setDate({clear: true});
 }

--- a/js/picker/Picker.js
+++ b/js/picker/Picker.js
@@ -3,6 +3,7 @@ import {today} from '../lib/date.js';
 import {parseHTML, getParent, showElement, hideElement, emptyChildNodes} from '../lib/dom.js';
 import {registerListeners} from '../lib/event.js';
 import pickerTemplate from './templates/pickerTemplate.js';
+import quickControlTemplate from './templates/quickControlTemplate.js';
 import DaysView from './views/DaysView.js';
 import MonthsView from './views/MonthsView.js';
 import YearsView from './views/YearsView.js';
@@ -15,6 +16,7 @@ import {
   onClickNextBtn,
   onClickView,
   onMousedownPicker,
+  onClickQuickControl,
 } from '../events/pickerListeners.js';
 
 const orientClasses = ['left', 'top', 'right', 'bottom'].reduce((obj, key) => {
@@ -150,6 +152,7 @@ export default class Picker {
     };
     this.main = main;
     this.controls = controls;
+    this.quickControls = title.nextElementSibling;
 
     const elementClass = datepicker.inline ? 'inline' : 'dropdown';
     element.classList.add(`datepicker-${elementClass}`);
@@ -184,6 +187,37 @@ export default class Picker {
     } else {
       datepicker.inputField.after(this.element);
     }
+  }
+
+  /**
+   * Adds a quick action button at the header of the picker.
+   * @param {Datepicker} datepicker parent picker object to get configuration
+   * @param {String} btnLabel label for the button
+   * @param {Function} controlDate a function that returns the Date to be selected
+   */
+   addQuickControlButton(datepicker, btnLabel, controlDate) {
+    // construct control element from template
+    const template = quickControlTemplate.replace(/%buttonClass%/g, datepicker.config.buttonClass);
+    const quickControlElement = parseHTML(template).firstElementChild;
+    const controlBtn = quickControlElement.firstElementChild;
+    controlBtn.textContent = btnLabel;
+    // add to quick controls placeholder
+    this.quickControls.appendChild(quickControlElement);
+    // register with picker listeners
+    registerListeners(datepicker, [[controlBtn, 'click', onClickQuickControl.bind(null, datepicker, controlDate)]]);
+  }
+
+  /**
+   * Removes the button with the label, if any was added as a quick control button.
+   * @param {String} btnLabel label of button, the text is case-sensitive to match
+   */
+  removeQuickControlButton(btnLabel) {
+    const qcButtons = this.quickControls.querySelectorAll('.quick-control-btn');
+    qcButtons.forEach(function(b) {
+      if (b.textContent === btnLabel) {
+        b.parentElement.remove();
+      }
+    });
   }
 
   setOptions(options) {

--- a/js/picker/templates/pickerTemplate.js
+++ b/js/picker/templates/pickerTemplate.js
@@ -4,6 +4,7 @@ const pickerTemplate = optimizeTemplateHTML(`<div class="datepicker">
   <div class="datepicker-picker">
     <div class="datepicker-header">
       <div class="datepicker-title"></div>
+      <div class="datepicker-quick-controls"></div>
       <div class="datepicker-controls">
         <button type="button" class="%buttonClass% prev-btn"></button>
         <button type="button" class="%buttonClass% view-switch"></button>

--- a/js/picker/templates/quickControlTemplate.js
+++ b/js/picker/templates/quickControlTemplate.js
@@ -1,0 +1,7 @@
+import {optimizeTemplateHTML} from '../../lib/utils.js';
+
+const quickControlTemplate = optimizeTemplateHTML(`<div class="datepicker-controls">
+        <button type="button" class="%buttonClass% quick-control-btn"></button>
+</div>`);
+
+export default quickControlTemplate;

--- a/sass/_mixins.scss
+++ b/sass/_mixins.scss
@@ -10,3 +10,8 @@
   width: 100%;
   font-size: $dp-font-size-small;
 }
+
+@mixin dp-quick-actions-button-common {
+  @include dp-footer-button-common;
+  font-weight: normal;
+}

--- a/sass/datepicker-bs4.scss
+++ b/sass/datepicker-bs4.scss
@@ -85,6 +85,12 @@ $dp-input-in-edit-focus-box-shadow-size: 0 0 0.25em 0.25em !default;
     .datepicker-footer & {
       @include dp-footer-button-common;
     }
+
+    .datepicker-quick-controls & {
+      .datepicker-header & {
+        @include dp-quick-actions-button-common;
+      }
+    }
   }
 }
 

--- a/sass/datepicker-bs5.scss
+++ b/sass/datepicker-bs5.scss
@@ -85,6 +85,12 @@ $dp-input-in-edit-focus-box-shadow-size: 0 0 0.25em 0.25em !default;
     .datepicker-footer & {
       @include dp-footer-button-common;
     }
+
+    .datepicker-quick-controls & {
+      .datepicker-header & {
+        @include dp-quick-actions-button-common;
+      }
+    }
   }
 }
 

--- a/sass/datepicker-bulma.scss
+++ b/sass/datepicker-bulma.scss
@@ -63,6 +63,12 @@ $dp-input-in-edit-focus-box-shadow-size: 0 0 0.25em 0.25em !default;
     .datepicker-footer & {
       @include dp-footer-button-common;
     }
+
+    .datepicker-quick-controls & {
+      .datepicker-header & {
+        @include dp-quick-actions-button-common;
+      }
+    }
   }
 }
 

--- a/sass/datepicker-foundation.scss
+++ b/sass/datepicker-foundation.scss
@@ -60,6 +60,12 @@ $dp-input-in-edit-focus-box-shadow-size: 0 0 0.25em 0.25em !default;
     .datepicker-footer & {
       @include dp-footer-button-common;
     }
+
+    .datepicker-quick-controls & {
+      .datepicker-header & {
+        @include dp-quick-actions-button-common;
+      }
+    }
   }
 }
 

--- a/sass/datepicker.scss
+++ b/sass/datepicker.scss
@@ -45,6 +45,8 @@ $dp-week-color: $grey-light !default;
 
 $dp-footer-background-color: $light !default;
 
+$dp-quick-control-background-color: $dp-footer-background-color !default;
+
 $dp-input-in-edit-border-color: darken($link, 5%) !default;
 $dp-input-in-edit-focus-box-shadow-size: 0 0 0.25em 0.25em !default;
 
@@ -96,6 +98,11 @@ $dp-cell-shrinked-width: $dp-cell-size-base * math.div(7, 8);
     -webkit-touch-callout: none;
     user-select: none;
   }
+}
+
+.datepicker-quick-controls {
+  box-shadow: inset 0 -1px 1px rgba($black, 0.1);
+  background-color: $dp-quick-control-background-color;
 }
 
 .datepicker-main {
@@ -238,6 +245,12 @@ $dp-cell-shrinked-width: $dp-cell-size-base * math.div(7, 8);
 
       .datepicker-footer & {
         @include dp-footer-button-common;
+      }
+
+      .datepicker-quick-controls & {
+        .datepicker-header & {
+          @include dp-quick-actions-button-common;
+        }
       }
     }
   }

--- a/test/unit/Datepicker.js
+++ b/test/unit/Datepicker.js
@@ -274,6 +274,12 @@ describe('Datepicker', function () {
     it('sets true to the picker.active property', function () {
       expect(dp.picker.active, 'to be true');
     });
+
+    it('do not show when input field is readonly', function () {
+        dp.hide();
+        input.setAttribute('readonly', '');
+        expect(dp.picker.active, 'not to be true');
+    });
   });
 
   describe('hide()', function () {

--- a/test/unit/Datepicker.js
+++ b/test/unit/Datepicker.js
@@ -312,6 +312,43 @@ describe('Datepicker', function () {
     });
   });
 
+  describe('quick Controls', function (){
+    let input;
+
+    before(function () {
+      input = document.createElement('input');
+      testContainer.appendChild(input);
+    });
+
+    after(function () {
+      document.querySelectorAll('.datepicker').forEach((el) => {
+        el.parentElement.removeChild(el);
+      });
+      delete input.datepicker;
+      testContainer.removeChild(input);
+    });
+
+    it('adds and then removes a quick control button', function () {
+      let dp = new Datepicker(input);
+      let btnLabel = 'Test';
+      dp.addQuickControl(btnLabel, () => new Date());
+      let ele = document.querySelector('.quick-control-btn');
+
+      expect(ele, 'not to be null');
+      expect(ele.textContent, 'to be', btnLabel);
+
+      dp.removeQuickControl(btnLabel);
+      ele = document.querySelector('.quick-control-btn');
+      expect(ele, 'to be null');
+    });
+
+    it('throws an error if date function is not passed', function () {
+      let dp = new Datepicker(input);
+      expect(() => dp.addQuickControl('Test', () => new Date('not a date format')), 'to throw',
+      'onClickQuickControl does not return Date');
+    });
+  });
+
   describe('static formatDate()', function () {
     it('formats a date or time value', function () {
       Datepicker.locales.es = esLocale;


### PR DESCRIPTION
Enhances Datepicker to allow user to extend picker by adding custom buttons with specified dates, like for example Yesterday, Start/End of Quarter, Birthdays :) and many more, user provided dates. Allows users to add more than one button, though not recommanded to have more than 2 for better UX.

This PR includes the changes to

1. Datepicker and DateRangepicker API to allow users to add button with label and function that provides the date.
2. Add implementation in Picker UI and a place holder for these buttons in pickerTemplate and add new quick control template
3. Add test cases to Datepicker to test new API
4. Styling to these new buttons, similar styling as Clear/Today button to be consistant with rest of UI
5. Finally, add them to demo code that demonstrates this new feature

Potential issues not tested are buttons are diplayed at top when Picker pops up than down; and when user provided function takes long time to return a date (calls a remote server etc.), could degrade the performance of Picker UI. Considering the simple scenarios of user function returns quickly returns outweights these issues, hopefully.