### PR TITLE
export package.json from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "./Datepicker": "./js/Datepicker.js",
     "./DateRangePicker": "./js/DateRangePicker.js",
     "./locales/*": "./js/i18n/locales/*.js",
-    "./locales/": "./js/i18n/locales/"
+    "./locales/": "./js/i18n/locales/",
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build:js": "rollup -c",


### PR DESCRIPTION
As weird as this sounds - someone has invented a rule now, that `package.json` should be exported from `package.json`.

Without this - some of the bundlers show a weird and annoying console log messages, like this one:

<img width="1271" alt="CleanShot 2022-10-28 at 10 36 36@2x" src="https://user-images.githubusercontent.com/392513/198556161-14c16c3d-672b-407b-8d6c-bc5335d6a450.png">


More details here: https://github.com/sveltejs/rollup-plugin-svelte/issues/181


If it's not a problem, please merge this 1 line and allow my OCD to move on 😉 