### PR TITLE
Add $dp-font-color variable to Sass template for Foundation

### DIFF
--- a/sass/datepicker-foundation.scss
+++ b/sass/datepicker-foundation.scss
@@ -1,6 +1,7 @@
 @use 'sass:color';
 
 $dp-background-color: $body-background !default;
+$dp-font-color: $body-font-color !default;
 $dp-border-color: $light-gray !default;
 $dp-border-radius: $global-radius !default;
 $dp-border-radius-small: $global-radius !default;
@@ -42,7 +43,7 @@ $dp-input-in-edit-focus-box-shadow-size: 0 0 0.25em 0.25em !default;
   .button {
     margin: 0;
     background-color: $dp-background-color;
-    color: $body-font-color;
+    color: $dp-font-color;
 
     &:hover,
     &:focus {
@@ -51,7 +52,7 @@ $dp-input-in-edit-focus-box-shadow-size: 0 0 0.25em 0.25em !default;
       &[disabled] {
         opacity: 0.25;  // $button-opacity-disabled
         background-color: $dp-background-color;
-        color: $body-font-color;
+        color: $dp-font-color;
       }
     }
 


### PR DESCRIPTION
Hi,

I'm using Sass template for Foundation and would like to suggest small improvement.

The `dp-button` mixin directly references value of `$body-font-color` variable from Foundation, so there is no way how to change it for datepicker component.

My suggestion is to introduce new `$dp-font-color` variable and use it in the mixin:
```scss
$dp-font-color: $body-font-color !default;
```

This keeps the template backwards-compatible and handles `$body-font-color` the same way as other Foundation variables like `$body-background` are handled.