### PR TITLE
feat: alwaysCaptureEnter option

### DIFF
--- a/js/events/elementListeners.js
+++ b/js/events/elementListeners.js
@@ -82,6 +82,10 @@ export function onKeydown(datepicker, ev) {
     } else if (editMode) {
       datepicker.exitEditMode({update: true, autohide: config.autohide});
     } else {
+      if (config.alwaysCaptureEnter) {
+        cancelEvent()
+      }
+      
       const currentView = picker.currentView;
       if (currentView.isMinView) {
         datepicker.setDate(picker.viewDate);

--- a/js/options/defaultOptions.js
+++ b/js/options/defaultOptions.js
@@ -34,4 +34,5 @@ export default {
   updateOnBlur: true,
   weekNumbers: 0,
   weekStart: 0,
+  alwaysCaptureEnter: false,
 };


### PR DESCRIPTION
This adds an option to allow always capturing the enter key when the datepicker is open. This for us is the expected behaviour, that when you can choose a date with arrow keys you can also select a date without submitting the form itself